### PR TITLE
Better GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
-/.idea/
-/src/test/
-RealMines.iml
+.idea/
+target/
+*.iml
+*.ipr
+*.iws
+*.class
+*.log
+*.ctxt
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar


### PR DESCRIPTION
Time to improve my future of RealMines development.

----
## The Problem 

When I edited a RealMines plugin several times and was going to Pull Request from my fork to the main repository, I always had to manually delete some files (e.g. those created after compiling with Maven) to prevent them from appearing in commits. 

----
## Solution 

This Pull Request extends and repairs the .gitignore file responsible for ignoring individual files, so no more unnecessary files.