### PR TITLE
Improve Maven Build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,5 +20,5 @@ jobs:
     - run: mvn --activate-profiles dist --no-transfer-progress package
     - uses: actions/upload-artifact@v3
       with:
-        name: RealMines
+        name: 'RealMines (Dev Build)'
         path: target/RealMines*.jar

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,11 +17,8 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - name: Extract Maven project version
-      run: echo ::set-output name=version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-      id: project
     - run: mvn --activate-profiles dist --no-transfer-progress package
     - uses: actions/upload-artifact@v3
       with:
         name: RealMines
-        path: target/RealMines-${{ steps.project.outputs.version }}.jar
+        path: target/RealMines*.jar


### PR DESCRIPTION
We will no longer get a project version to speed up compile time. In my last Pull Request it took two hours to compile Maven because of the Extract Project Version step.