### PR TITLE
Countdown persistence and modifiability

### DIFF
--- a/realmines-api/src/main/java/joserodpt/realmines/api/config/TranslatableLine.java
+++ b/realmines-api/src/main/java/joserodpt/realmines/api/config/TranslatableLine.java
@@ -24,6 +24,8 @@ public enum TranslatableLine {
     MINE_RESET_WARNING("Mines.Reset.Warning", ReplacableVar.MINE),
     MINE_TELEPORT("Mines.Teleport", ReplacableVar.MINE),
     MINE_TELEPORT_SET("Mines.Teleport-Set", ReplacableVar.MINE),
+    MINE_COUNTDOWN_SET("Mines.Countdown-Set", ReplacableVar.MINE, ReplacableVar.TIME),
+    MINE_COUNTDOWN_SET_UNSUCCESSFUL("Mines.Countdown-Set-Unsuccessful", ReplacableVar.MINE),
     MINE_NO_TELEPORT_LOCATION("Mines.No-Teleport-Location"),
     // break actions
     MINE_BREAK_ACTION_GIVE_MONEY("Mines.Break-Actions.Give-Money", ReplacableVar.MONEY),

--- a/realmines-api/src/main/java/joserodpt/realmines/api/utils/Countdown.java
+++ b/realmines-api/src/main/java/joserodpt/realmines/api/utils/Countdown.java
@@ -119,6 +119,14 @@ public class Countdown implements Runnable {
         return this.secondsLeft;
     }
 
+    /**
+     * Sets the seconds left for this timer
+     * @param secondsLeft Seconds left
+     */
+    public void setSecondsLeft(int secondsLeft) {
+        this.secondsLeft = secondsLeft;
+    }
+
     public Integer getTaskId() {
         return this.assignedTaskId;
     }

--- a/realmines-plugin/src/main/java/joserodpt/realmines/plugin/RealMinesPlugin.java
+++ b/realmines-plugin/src/main/java/joserodpt/realmines/plugin/RealMinesPlugin.java
@@ -59,10 +59,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -164,6 +161,18 @@ public class RealMinesPlugin extends JavaPlugin {
 
         commandManager.registerSuggestion(SuggestionKey.of("#minetasks"),
                 (sender, context) -> realMines.getMineResetTasksManager().getRegisteredTasks()
+        );
+
+        commandManager.registerSuggestion(SuggestionKey.of("#minecountdowns"),
+                (sender, context) -> {
+                    RMine mine = realMines.getMineManager().getMine(context.getArgs().get(0));
+                    if (mine != null && mine.getMineTimer() != null && mine.getMineTimer().getCountdown() != null) {
+                        Integer countdown = mine.getCountdown();
+                        if (countdown == null) return List.of();
+                        return List.of(countdown.toString());
+                    }
+                    return List.of();
+                }
         );
 
         //registo de comandos #portugal

--- a/realmines-plugin/src/main/java/joserodpt/realmines/plugin/command/MineCMD.java
+++ b/realmines-plugin/src/main/java/joserodpt/realmines/plugin/command/MineCMD.java
@@ -176,6 +176,49 @@ public class MineCMD extends BaseCommandWA {
         }
     }
 
+    @SubCommand("setcountdown")
+    @Permission("realmines.admin")
+    @WrongUsage("&c/mine setcountdown <name> <seconds>")
+    public void setcountdowncmd(final CommandSender commandSender, @Suggestion("#mines") final String name, @Suggestion("#minecountdowns") final Integer seconds) {
+        if (commandSender instanceof Player) {
+            final RMine m = rm.getMineManager().getMine(name);
+            if (m != null) {
+                boolean success = m.setCountdown(seconds, true);
+                if (success) {
+                    TranslatableLine.MINE_COUNTDOWN_SET.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).setV2(TranslatableLine.ReplacableVar.TIME.eq(String.valueOf(seconds))).send(commandSender);
+                } else {
+                    TranslatableLine.MINE_COUNTDOWN_SET_UNSUCCESSFUL.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).send(commandSender);
+                }
+            } else {
+                TranslatableLine.SYSTEM_MINE_DOESNT_EXIST.send(commandSender);
+            }
+        }
+    }
+
+    @SubCommand("resetcountdown")
+    @Permission("realmines.admin")
+    @WrongUsage("&c/mine resetcountdown <name>")
+    public void resetcountdowncmd(final CommandSender commandSender, @Suggestion("#mines") final String name) {
+        if (commandSender instanceof Player) {
+            final RMine m = rm.getMineManager().getMine(name);
+            if (m != null) {
+                boolean success = m.resetCountdown(true);
+                if (success) {
+                    TranslatableLine line = TranslatableLine.MINE_COUNTDOWN_SET.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName()));
+                    Integer countdown = m.getCountdown();
+                    if (countdown != null) {
+                        line.setV2(TranslatableLine.ReplacableVar.TIME.eq(String.valueOf(countdown)));
+                    }
+                    line.send(commandSender);
+                } else {
+                    TranslatableLine.MINE_COUNTDOWN_SET_UNSUCCESSFUL.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).send(commandSender);
+                }
+            } else {
+                TranslatableLine.SYSTEM_MINE_DOESNT_EXIST.send(commandSender);
+            }
+        }
+    }
+
     @SubCommand("tp")
     @Permission("realmines.tp")
     @WrongUsage("&c/mine tp <name>")

--- a/realmines-plugin/src/main/java/joserodpt/realmines/plugin/command/MineCMD.java
+++ b/realmines-plugin/src/main/java/joserodpt/realmines/plugin/command/MineCMD.java
@@ -180,18 +180,16 @@ public class MineCMD extends BaseCommandWA {
     @Permission("realmines.admin")
     @WrongUsage("&c/mine setcountdown <name> <seconds>")
     public void setcountdowncmd(final CommandSender commandSender, @Suggestion("#mines") final String name, @Suggestion("#minecountdowns") final Integer seconds) {
-        if (commandSender instanceof Player) {
-            final RMine m = rm.getMineManager().getMine(name);
-            if (m != null) {
-                boolean success = m.setCountdown(seconds, true);
-                if (success) {
-                    TranslatableLine.MINE_COUNTDOWN_SET.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).setV2(TranslatableLine.ReplacableVar.TIME.eq(String.valueOf(seconds))).send(commandSender);
-                } else {
-                    TranslatableLine.MINE_COUNTDOWN_SET_UNSUCCESSFUL.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).send(commandSender);
-                }
+        final RMine m = rm.getMineManager().getMine(name);
+        if (m != null) {
+            boolean success = m.setCountdown(seconds, true);
+            if (success) {
+                TranslatableLine.MINE_COUNTDOWN_SET.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).setV2(TranslatableLine.ReplacableVar.TIME.eq(String.valueOf(seconds))).send(commandSender);
             } else {
-                TranslatableLine.SYSTEM_MINE_DOESNT_EXIST.send(commandSender);
+                TranslatableLine.MINE_COUNTDOWN_SET_UNSUCCESSFUL.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).send(commandSender);
             }
+        } else {
+            TranslatableLine.SYSTEM_MINE_DOESNT_EXIST.send(commandSender);
         }
     }
 
@@ -199,23 +197,21 @@ public class MineCMD extends BaseCommandWA {
     @Permission("realmines.admin")
     @WrongUsage("&c/mine resetcountdown <name>")
     public void resetcountdowncmd(final CommandSender commandSender, @Suggestion("#mines") final String name) {
-        if (commandSender instanceof Player) {
-            final RMine m = rm.getMineManager().getMine(name);
-            if (m != null) {
-                boolean success = m.resetCountdown(true);
-                if (success) {
-                    TranslatableLine line = TranslatableLine.MINE_COUNTDOWN_SET.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName()));
-                    Integer countdown = m.getCountdown();
-                    if (countdown != null) {
-                        line.setV2(TranslatableLine.ReplacableVar.TIME.eq(String.valueOf(countdown)));
-                    }
-                    line.send(commandSender);
-                } else {
-                    TranslatableLine.MINE_COUNTDOWN_SET_UNSUCCESSFUL.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).send(commandSender);
+        final RMine m = rm.getMineManager().getMine(name);
+        if (m != null) {
+            boolean success = m.resetCountdown(true);
+            if (success) {
+                TranslatableLine line = TranslatableLine.MINE_COUNTDOWN_SET.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName()));
+                Integer countdown = m.getCountdown();
+                if (countdown != null) {
+                    line.setV2(TranslatableLine.ReplacableVar.TIME.eq(String.valueOf(countdown)));
                 }
+                line.send(commandSender);
             } else {
-                TranslatableLine.SYSTEM_MINE_DOESNT_EXIST.send(commandSender);
+                TranslatableLine.MINE_COUNTDOWN_SET_UNSUCCESSFUL.setV1(TranslatableLine.ReplacableVar.MINE.eq(m.getDisplayName())).send(commandSender);
             }
+        } else {
+            TranslatableLine.SYSTEM_MINE_DOESNT_EXIST.send(commandSender);
         }
     }
 

--- a/realmines-plugin/src/main/java/joserodpt/realmines/plugin/managers/MineManager.java
+++ b/realmines-plugin/src/main/java/joserodpt/realmines/plugin/managers/MineManager.java
@@ -379,6 +379,7 @@ public class MineManager extends MineManagerAPI {
     @Override
     public void unloadMines() {
         for (RMine mine : this.getMines().values()) {
+            mine.saveAllOf(List.of(RMine.MineData.COUNTDOWN), true);
             if (mine.getMineTimer() != null) {
                 mine.getMineTimer().kill();
             }

--- a/realmines-plugin/src/main/resources/language.yml
+++ b/realmines-plugin/src/main/resources/language.yml
@@ -6,6 +6,8 @@ Mines:
     Warning: "&7[&6Warning&7] &r%mine% &fwill reset in &b%time% &9seconds."
   Teleport: "&fTeleported to mine &9%mine%"
   Teleport-Set: "&fTeleport &Aset &ffor mine %mine%"
+  Countdown-Set: "&fCountdown &aset &ffor mine %mine% to &b%time% &fseconds."
+  Countdown-Set-Unsuccessful: "&cCould not set countdown for mine %mine%. Invalid time or mine cannot be reset by time."
   No-Teleport-Location: "&fThis mine &cdoesnt have a teleport location."
   Break-Actions:
     Give-Money: "&fYou just recieved &b%money% coins &ffor breaking this block! &eLucky you!"


### PR DESCRIPTION
- Exposed Countdown secondsLeft in Countdown#getSecondsLeft and Countdown#setSecondsLeft.
- Added countdown int getter in RMine, save methods and usage of them on unload.
- Added countdown config key (`reset.time.countdown`).
- Mine countdown persists after reload and/or server restart.
- Added setcountdown and resetcoutdown commands.
- Added language keys for such commands.