### PR TITLE
Pass Cancellable to MineBlockBreakEvent

### DIFF
--- a/realmines-api/src/main/java/joserodpt/realmines/api/event/MineBlockBreakEvent.java
+++ b/realmines-api/src/main/java/joserodpt/realmines/api/event/MineBlockBreakEvent.java
@@ -17,6 +17,7 @@ import joserodpt.realmines.api.mine.RMine;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -25,16 +26,22 @@ public class MineBlockBreakEvent extends Event {
 
     private static final HandlerList HANDLERS = new HandlerList();
 
+    private final Cancellable cancellable;
     private final RMine mine;
     private final boolean broken;
     private final Block b;
     private final Player p;
 
-    public MineBlockBreakEvent(final Player p, final RMine m, final Block b, final boolean broken) {
+    public MineBlockBreakEvent(final Cancellable cancellable, final Player p, final RMine m, final Block b, final boolean broken) {
+        this.cancellable = cancellable;
         this.p = p;
         this.mine = m;
         this.b = b;
         this.broken = broken;
+    }
+
+    public Cancellable getCancellable() {
+        return cancellable;
     }
 
     public Block getBlock() {

--- a/realmines-plugin/src/main/java/joserodpt/realmines/plugin/managers/MineManager.java
+++ b/realmines-plugin/src/main/java/joserodpt/realmines/plugin/managers/MineManager.java
@@ -357,8 +357,10 @@ public class MineManager extends MineManagerAPI {
                             if (mi.isBlockMiningDisabled()) {
                                 e.setCancelled(true);
                             } else {
-                                Bukkit.getPluginManager().callEvent(new MineBlockBreakEvent(p, mine, block, broken));
-                                return mine.getMineItems().get(block.getType());
+                                Bukkit.getPluginManager().callEvent(new MineBlockBreakEvent(e, p, mine, block, broken));
+                                if (!e.isCancelled()) {
+                                    return mine.getMineItems().get(block.getType());
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
What the title says.
Pass the Cancellable instance to MineBlockBreakEvent so it's aware of players that can or cannot break mine blocks due to bukkit events getting cancelled.